### PR TITLE
LRDOCS-10322 Remove Best Keyword and Best Paid Keyword information, since this info is never shown in the Content Performance Panel

### DIFF
--- a/docs/dxp/latest/en/content-authoring-and-management/page-performance-and-accessibility/analyze-content-metrics-using-content-performance-tool.md
+++ b/docs/dxp/latest/en/content-authoring-and-management/page-performance-and-accessibility/analyze-content-metrics-using-content-performance-tool.md
@@ -71,8 +71,6 @@ The following table describes the metrics you can find in the Traffic Channels a
 | :--- | :--- |
 | Traffic Volume | The estimated number of visitors to your Page. |
 | Traffic Share | Percentage of traffic your content receives from the traffic source. |
-| Best Keyword | Top five keywords driving traffic through organic search. |
-| Best Paid Keyword | Top five keywords driving traffic through paid search. |
 | Top Referring Social Media | Top ten social media networks driving traffic to your Page. |
 | Top Referring Pages | Top ten referrer Pages driving traffic to your Page. |
 | Top Referring Domains | Top ten referrer domains driving traffic to your Page. |


### PR DESCRIPTION
Hey @Fabiomorais87 !!

I am Cristina,  Tango Team Lead.

I would need to delete the references to the Best Keyword and Best Paid Keyword in the documentation, since these features are no longer supported.

I think that with this change is enough, do you need something more on my side?


Thanks!!